### PR TITLE
✨ (src/whatsapp): Add downloadAudio function

### DIFF
--- a/src/whatsapp.js
+++ b/src/whatsapp.js
@@ -1,0 +1,25 @@
+const fs = require('fs/promises');
+
+/**
+ * Download audio from whatsapp message
+ * @param {Message} msg - Whatsapp message
+ * @param {string} path - Path to save the audio
+ * @return {boolean} - True if the message is a voice clip and was downloaded,
+ *                   false otherwise
+ */
+async function downloadAudio(msg, path) {
+	if (msg.type === 'ptt' || msg.type === 'audio') {
+		const attachedData = await msg.downloadMedia();
+		const binaryData = Buffer.from(attachedData.data, 'base64');
+		try {
+			await fs.writeFile(path, binaryData);
+			return true;
+		} catch (error) {
+			console.log('Error writing to file:', error);
+			throw error;
+		}
+	}
+	throw Error(`The message type is: ${msg.type} expected: 'audio' or 'ptt'`);
+}
+
+module.exports = { downloadAudio };

--- a/test/unit/whatsapp/whatsapp.test.js
+++ b/test/unit/whatsapp/whatsapp.test.js
@@ -1,0 +1,62 @@
+const { expect } = require('chai');
+const { downloadAudio } = require('../../../src/whatsapp.js'); // Replace with the actual module path
+const fs = require('fs-extra');
+const path = require('path');
+
+// Mocking a WhatsApp message object for testing
+class MockMessage {
+	constructor(type, data) {
+		this.type = type;
+		this.data = data;
+	}
+
+	async downloadMedia() {
+		return {
+			data: this.data,
+		};
+	}
+}
+
+describe('downloadAudio', () => {
+	let tempDir;
+
+	before(function () {
+		// Create a temporary directory before running tests
+		tempDir = path.join(__dirname, 'temp'); // Use a directory name that makes sense for your project
+		fs.ensureDirSync(tempDir); // Create the directory if it doesn't exist
+	});
+
+	after(function () {
+		// Remove the temporary directory after running tests
+		fs.removeSync(tempDir);
+	});
+
+	it('should download and save audio when the message type is "ptt"', async () => {
+		const msg = new MockMessage('ptt', 'base64-encoded-audio-data');
+		downloadPath = `${tempDir}/audio_ptt.ogg`;
+		const result = await downloadAudio(msg, downloadPath);
+		expect(result).to.equal(true);
+		expect(fs.existsSync(downloadPath)).to.equal(true);
+	});
+
+	it('should download and save audio when the message type is "audio"', async () => {
+		const msg = new MockMessage('audio', 'base64-encoded-audio-data');
+		downloadPath = `${tempDir}/audio_audio.ogg`;
+		const result = await downloadAudio(msg, downloadPath);
+		expect(result).to.equal(true);
+		expect(fs.existsSync(downloadPath)).to.equal(true);
+	});
+
+	it('should throw an error for an unsupported message type', async () => {
+		const msg = new MockMessage('unsupported', 'base64-encoded-data');
+		downloadPath = `${tempDir}/audio_audio.mp3`;
+		try {
+			await downloadAudio(msg, path);
+			// If no error is thrown, fail the test
+			expect(fs.existsSync(downloadPath)).to.equal(false);
+			expect.fail('Expected an error to be thrown');
+		} catch (error) {
+			expect(error.message).to.include("expected: 'audio' or 'ptt'");
+		}
+	});
+});


### PR DESCRIPTION
This commit adds a new function called `downloadAudio` to the `whatsapp.js` file. This function is responsible for downloading audio from a WhatsApp message and saving it to a specified path. It takes in a `Message` object and a path as parameters. If the message type is either ptt or audio, the function downloads the attached data, converts it to binary, and writes it to the specified path using the `fs.writeFile` method. If the message type is not supported, an error is thrown.

✅ (test/unit/whatsapp): Add tests for downloadAudio function

This commit adds unit tests for the `downloadAudio` function in the `whatsapp.test.js` file. The tests cover the scenarios where the message type is ptt, audio, and an unsupported type. The tests ensure that the function correctly downloads and saves the audio when the message type is supported, and throws an error when the message type is not supported.